### PR TITLE
Added temporary loading screen while github login finishes on backend.

### DIFF
--- a/meditrack/package-lock.json
+++ b/meditrack/package-lock.json
@@ -30,6 +30,7 @@
         "react-calendar": "^4.3.0",
         "react-datepicker": "^4.15.0",
         "react-dom": "^18.2.0",
+        "react-github-login-button": "^1.0.1",
         "react-redux": "^8.1.1",
         "react-router": "^6.14.1",
         "react-router-dom": "^6.14.1",
@@ -16159,6 +16160,17 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-github-login-button": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-github-login-button/-/react-github-login-button-1.0.1.tgz",
+      "integrity": "sha512-HXtYwgy8EwR9i+W5HgP1d/Ndf28AXLgc2l7TQwDQfn3Tf6PeS7xD0vqF+xGAfvqKOx6rFWP5E5wpAaoC8wzirw==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/meditrack/package.json
+++ b/meditrack/package.json
@@ -25,6 +25,7 @@
     "react-calendar": "^4.3.0",
     "react-datepicker": "^4.15.0",
     "react-dom": "^18.2.0",
+    "react-github-login-button": "^1.0.1",
     "react-redux": "^8.1.1",
     "react-router": "^6.14.1",
     "react-router-dom": "^6.14.1",

--- a/meditrack/src/components/Home.jsx
+++ b/meditrack/src/components/Home.jsx
@@ -2,6 +2,8 @@ import React, {useEffect, useState} from 'react';
 import { Link } from 'react-router-dom'
 import {useNavigate} from 'react-router-dom'
 import logo from '../logo.png';
+import GithubButton from 'react-github-login-button'
+import IsLoading from './isLoading';
 import './Home.css';
 const CLIENT_ID = "1f252291952872a24f19"
 let cookieValue;
@@ -11,6 +13,7 @@ let cookieValue;
 const Home = () => {
     const [rerender, setRerender] = useState(false)
     const navigate = useNavigate();
+    const [isLoading ,setIsLoading] = useState(false)
 
     useEffect(()=> {
         const urlParams = new URLSearchParams(document.location.search)
@@ -20,6 +23,7 @@ const Home = () => {
         console.log("this is first cookie value", cookieValue)
 
         if(codeParam && (cookieValue === "")){
+            setIsLoading(true)
             console.log("before making call to /getAccessToken")
             async function getAccessToken(){
                 await fetch("/api/getAccessToken?code=" + codeParam, {
@@ -28,13 +32,14 @@ const Home = () => {
                     return response.json();
                 }).then((data)=>{
                     if(data._id){
+                        setIsLoading(false)
                         navigate(`/dashboard`);
                     }
                 })
             }  
         getAccessToken();
         }
-    }, [rerender])
+    }, [rerender, navigate])
 
     function getCookie(cname) {
         let name = cname + "=";
@@ -54,13 +59,16 @@ const Home = () => {
 
     function loginWithGithub() {
         window.location.assign("https://github.com/login/oauth/authorize?client_id=" + CLIENT_ID)
+        setRerender(!rerender)
       }
 
     return(
+        // {isLoading ? <isLoading/> :}
+        <> {isLoading ? <IsLoading/> :
         <div className="homepage-container">
             <h1>MediTrack</h1>
             <h3>Please <Link className="link" to="/login">login</Link> or <Link className="link" to="signup">signup</Link> to continue</h3>
-            <button onClick={loginWithGithub}>Login with Github</button>
+            <GithubButton style={{margin: "auto"}} onClick={loginWithGithub}/>
             <div className="home section__padding">
             <div className="home-image">
             <img src={logo} alt="logo" />
@@ -71,6 +79,8 @@ const Home = () => {
             </div>
         </div>
          </div>
+    }
+         </>
     );
 
 

--- a/meditrack/src/components/IsLoading.jsx
+++ b/meditrack/src/components/IsLoading.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function IsLoading() {
+  return (
+    <div>IsLoading</div>
+  )
+}
+
+export default IsLoading


### PR DESCRIPTION
## Description
Added styled signup with GitHub button and a loading screen that removes all components from screen to prevent user from clicking multiple times on button.

## Related Issue
User could click multiple times on signup with github button before fetch request was done with all the backend functionality and this would cause issues with application.

## Motivation and Context
This fix will prevent user from clicking multiple times signup button.

## How Has This Been Tested?
Tested several times by logging in and out with github login and fix worked as intended. It removed the button and it waits until the fetch request is done before it redirects to Dashboard.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.